### PR TITLE
README links revised to be relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ See (openshift/Readme.md)
 
 ## Getting Help or Reporting an Issue
 
-To report bugs/issues/feature requests, please file an [issue](https://github.com/BCDevOps/opendev-template/issues/).
+To report bugs/issues/feature requests, please file an [issue](../../issues).
 
 ## How to Contribute
 
-If you would like to contribute, please see our [CONTRIBUTING](CONTRIBUTING.md) guidelines.
+If you would like to contribute, please see our [CONTRIBUTING](./CONTRIBUTING.md) guidelines.
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). 
+Please note that this project is released with a [Contributor Code of Conduct](./CODE_OF_CONDUCT.md). 
 By participating in this project you agree to abide by its terms.
 
 ## License


### PR DESCRIPTION
So that forked repos can re-use that same text.